### PR TITLE
Bump windows build timeout for cuda tests

### DIFF
--- a/src/jobs/caffe2.groovy
+++ b/src/jobs/caffe2.groovy
@@ -785,7 +785,7 @@ Images.windowsBuildEnvironments.each {
   job("${buildBasePath}/${buildEnvironment}-build") {
     JobUtil.common(delegate, 'windows && cpu')
     JobUtil.gitCommitFromPublicGitHub(delegate, '${GITHUB_REPO}')
-    JobUtil.timeoutAndFailAfter(delegate, 60)
+    JobUtil.timeoutAndFailAfter(delegate, 90)
 
     parameters {
       ParametersUtil.GIT_COMMIT(delegate)


### PR DESCRIPTION
This PR is to avoid the timeout in windows test: 
https://ci.pytorch.org/jenkins/job/caffe2-builds/job/py2-cuda9.0-cudnn7-windows-build/11547/console

The timeout happened because we start building aten in that test. 
