### PR TITLE
Add cudaVersion argument for Horizon

### DIFF
--- a/src/jobs/horizon.groovy
+++ b/src/jobs/horizon.groovy
@@ -153,6 +153,14 @@ Images.dockerImages.each {
     steps {
       GitUtil.mergeStep(delegate)
 
+      def cudaVersion = ''
+      if (buildEnvironment.contains('cuda')) {
+        // 'native' indicates to let the nvidia runtime figure out which version
+        // of CUDA to use. This is only possible when using the nvidia/cuda
+        // Docker images.
+        cudaVersion = 'native';
+      }
+
       environmentVariables {
         // TODO: Will be obsolete once this is baked into docker image
         env(
@@ -167,6 +175,7 @@ Images.dockerImages.each {
 
       DockerUtil.shell context: delegate,
               image: dockerImage('${BUILD_ENVIRONMENT}','${DOCKER_IMAGE_TAG}'),
+              cudaVersion: cudaVersion,
               workspaceSource: "host-copy",
               script: '''
 .jenkins/build.sh


### PR DESCRIPTION
Trying to fix libcuda.so.1 not found. Copied from https://github.com/pytorch/ossci-job-dsl/blob/77a34f91dfe122b7bd3a4ea853553a4b31618414/src/jobs/caffe2.groovy#L482-L493