### PR TITLE
Update DockerVersion with dependencies for Caffe2 tests in PyTorch

### DIFF
--- a/src/main/groovy/ossci/pytorch/DockerVersion.groovy
+++ b/src/main/groovy/ossci/pytorch/DockerVersion.groovy
@@ -1,6 +1,6 @@
 // This file is manually managed
 package ossci.pytorch
 class DockerVersion {
-  static final String version = "262";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
-  static final String allDeployedVersions = "262,256";  // NOTE: this is a comma-separated list. E.g. "262,220,219"
+  static final String version = "271";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
+  static final String allDeployedVersions = "271,262,256";  // NOTE: this is a comma-separated list. E.g. "262,220,219"
 }


### PR DESCRIPTION
Docker images have been updated with dependencies needed for Caffe2 tests in PyTorch. Most of this landed with https://github.com/pietern/pytorch-dockerfiles/pull/26

@yf225 @pjh5 