### PR TITLE
bump docker version for newer magma

### DIFF
--- a/src/main/groovy/ossci/pytorch/DockerVersion.groovy
+++ b/src/main/groovy/ossci/pytorch/DockerVersion.groovy
@@ -1,6 +1,6 @@
 // This file is manually managed
 package ossci.pytorch
 class DockerVersion {
-  static final String version = "282";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
-  static final String allDeployedVersions = "271,262,256,278,282";  // NOTE: this is a comma-separated list. E.g. "262,220,219"
+  static final String version = "291";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
+  static final String allDeployedVersions = "271,262,256,278,282,291";  // NOTE: this is a comma-separated list. E.g. "262,220,219"
 }


### PR DESCRIPTION
Updated magma via commit https://github.com/pietern/pytorch-dockerfiles/commit/a06f8c4020112fdc6c1ac755ce3b475aa8d7fd51