### PR TITLE
Add Ubuntu bionic docker image.

### DIFF
--- a/src/jobs/pytorch_docker.groovy
+++ b/src/jobs/pytorch_docker.groovy
@@ -2,6 +2,7 @@ import javaposse.jobdsl.dsl.helpers.step.MultiJobStepContext
 import ossci.pytorch.Users
 
 def dockerImages = [
+  "pytorch-linux-bionic-clang9-thrift-llvmdev",
   "pytorch-linux-xenial-py2.7.9",
   "pytorch-linux-xenial-py2.7",
   "pytorch-linux-xenial-py3.5",


### PR DESCRIPTION
  Adds the docker image pytorch-linux-bionic-clang9-thrift-llvmdev"
  to the list of pytorch images.