### PR TITLE
Revert "use circleci rocm images (#67)"

### DIFF
--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -45,8 +45,8 @@ def buildEnvironments = [
   // "pytorch-macos-10.13-py3",
   // "pytorch-macos-10.13-cuda9.2-cudnn7-py3",
 
-  // NB: This image is taken from CircleCI
-  "pytorch-linux-xenial-rocm3.3-py3.6",
+  // NB: This image is taken from Caffe2
+  "py3.6-clang7-rocmdeb-ubuntu16.04",
 
   // This is really expensive to run because it is a total build
   // from scratch.  Maybe we have to do it nightly.
@@ -75,12 +75,14 @@ def splitTestEnvironments = [
   "pytorch-linux-xenial-py3-clang5-asan",
   "py3.6-clang7-rocmdeb-ubuntu16.04",
   "py3.6-clang8-rocmdeb-ubuntu16.04",
-  "pytorch-linux-xenial-rocm3.3-py3.6",
 ]
 def avxConfigTestEnvironment = "pytorch-linux-xenial-cuda8-cudnn6-py3"
 
 // Every build environment has its own Docker image
 def dockerImage = { staticBuildEnv, buildEnvironment, tag, caffe2_tag ->
+  if (isRocmBuild(staticBuildEnv)) {
+    return "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/${buildEnvironment}:${caffe2_tag}"
+  }
   return "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${buildEnvironment}:${tag}"
 }
 

--- a/src/main/groovy/ossci/caffe2/DockerVersion.groovy
+++ b/src/main/groovy/ossci/caffe2/DockerVersion.groovy
@@ -1,6 +1,6 @@
 // This file is manually managed
 package ossci.caffe2
 class DockerVersion {
-  static final String version = "be76e8fd-44e2-484d-b090-07e0cc3a56f0";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
+  static final String version = "376";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
   static final String allDeployedVersions = "376,373,348,345,336,325,324,315,306,301,287,283,276,273,266,253,248,238,230,213";  // NOTE: this is a comma-separated list. E.g. "262,220,219"
 }

--- a/src/main/groovy/ossci/caffe2/Images.groovy
+++ b/src/main/groovy/ossci/caffe2/Images.groovy
@@ -258,7 +258,7 @@ class Images {
     // Vanilla Ubuntu 14.04
     // 'py2-gcc4.8-ubuntu14.04',
 
-    'pytorch-linux-xenial-rocm3.3-py3.6',
+    'py3.6-devtoolset7-rocmrpm-centos7',
   ];
 
   static final List<String> buildOnlyEnvironments = [

--- a/src/main/groovy/ossci/pytorch/DockerVersion.groovy
+++ b/src/main/groovy/ossci/pytorch/DockerVersion.groovy
@@ -7,7 +7,7 @@ package ossci.pytorch
 class DockerVersion {
   // WARNING: if you change this to a new version number,
   // you **MUST** also add that version number to the allDeployedVersions list below
-  static final String version = "be76e8fd-44e2-484d-b090-07e0cc3a56f0";
+  static final String version = "405";
 
   // NOTE: this is a comma-separated list. E.g. "262,220,219"
   static final String allDeployedVersions = "271,262,256,278,282,291,300,323,327,347,389,401,402,403,405";


### PR DESCRIPTION
This reverts commit d5efdbe887a386a01b5639517950039d337de234.

Not all tests were present on the CI dashboard.  The one visible build job appeared to succeed, but test1 failed to import torch.  Need to revert until post mortem can be completed.

CC @ezyang @xw285cornell @sunway513 