### PR TITLE
For ROCm, switch from caffe2 base images to pytorch base images.

### DIFF
--- a/src/jobs/caffe2.groovy
+++ b/src/jobs/caffe2.groovy
@@ -67,6 +67,9 @@ Images.allDockerBuildEnvironments.each {
 
   // Every build environment has its own Docker image
   def dockerImage = { tag ->
+    if (buildEnvironment.contains("rocm")) {
+      return "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${dockerBaseImage}:${tag}"
+    }
     return "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/${dockerBaseImage}:${tag}"
   }
 

--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -46,7 +46,8 @@ def buildEnvironments = [
   // "pytorch-macos-10.13-cuda9.2-cudnn7-py3",
 
   // NB: This image is taken from Caffe2
-  "py3.6-clang7-rocmdeb-ubuntu16.04",
+  //"py3.6-clang7-rocmdeb-ubuntu16.04",
+  "pytorch-linux-xenial-rocm3.3-py3.6",
 
   // This is really expensive to run because it is a total build
   // from scratch.  Maybe we have to do it nightly.
@@ -75,14 +76,12 @@ def splitTestEnvironments = [
   "pytorch-linux-xenial-py3-clang5-asan",
   "py3.6-clang7-rocmdeb-ubuntu16.04",
   "py3.6-clang8-rocmdeb-ubuntu16.04",
+  "pytorch-linux-xenial-rocm3.3-py3.6",
 ]
 def avxConfigTestEnvironment = "pytorch-linux-xenial-cuda8-cudnn6-py3"
 
 // Every build environment has its own Docker image
 def dockerImage = { staticBuildEnv, buildEnvironment, tag, caffe2_tag ->
-  if (isRocmBuild(staticBuildEnv)) {
-    return "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/${buildEnvironment}:${caffe2_tag}"
-  }
   return "308535385114.dkr.ecr.us-east-1.amazonaws.com/pytorch/${buildEnvironment}:${tag}"
 }
 

--- a/src/main/groovy/ossci/caffe2/DockerVersion.groovy
+++ b/src/main/groovy/ossci/caffe2/DockerVersion.groovy
@@ -1,6 +1,6 @@
 // This file is manually managed
 package ossci.caffe2
 class DockerVersion {
-  static final String version = "376";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
+  static final String version = "be76e8fd-44e2-484d-b090-07e0cc3a56f0";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
   static final String allDeployedVersions = "376,373,348,345,336,325,324,315,306,301,287,283,276,273,266,253,248,238,230,213";  // NOTE: this is a comma-separated list. E.g. "262,220,219"
 }

--- a/src/main/groovy/ossci/caffe2/Images.groovy
+++ b/src/main/groovy/ossci/caffe2/Images.groovy
@@ -83,10 +83,11 @@ class Images {
     //'py3.6-devtoolset7-cuda10.1-cudnn7-centos7',
 
      // AMD ROCM builds
-    'py3.6-clang7-rocmdeb-ubuntu16.04',
-    'py3.6-clang8-rocmdeb-ubuntu16.04',
-    'py2-devtoolset7-rocmrpm-centos7.5',
-    'py3.6-devtoolset7-rocmrpm-centos7',
+    //'py3.6-clang7-rocmdeb-ubuntu16.04',
+    //'py3.6-clang8-rocmdeb-ubuntu16.04',
+    //'py2-devtoolset7-rocmrpm-centos7.5',
+    //'py3.6-devtoolset7-rocmrpm-centos7',
+    'pytorch-linux-xenial-rocm3.3-py3.6',
   ];
 
   /////////////////////////////////////////////////////////////////////////////
@@ -258,7 +259,8 @@ class Images {
     // Vanilla Ubuntu 14.04
     // 'py2-gcc4.8-ubuntu14.04',
 
-    'py3.6-devtoolset7-rocmrpm-centos7',
+    //'py3.6-devtoolset7-rocmrpm-centos7',
+    'pytorch-linux-xenial-rocm3.3-py3.6',
   ];
 
   static final List<String> buildOnlyEnvironments = [

--- a/src/main/groovy/ossci/pytorch/DockerVersion.groovy
+++ b/src/main/groovy/ossci/pytorch/DockerVersion.groovy
@@ -7,7 +7,7 @@ package ossci.pytorch
 class DockerVersion {
   // WARNING: if you change this to a new version number,
   // you **MUST** also add that version number to the allDeployedVersions list below
-  static final String version = "405";
+  static final String version = "be76e8fd-44e2-484d-b090-07e0cc3a56f0";
 
   // NOTE: this is a comma-separated list. E.g. "262,220,219"
   static final String allDeployedVersions = "271,262,256,278,282,291,300,323,327,347,389,401,402,403,405";


### PR DESCRIPTION
These images are created from the CircleCI scripts and are used for both pytorch and caffe2 builds and tests.