### PR TITLE
Revert "reland upgrade rocm image to 3.5.1 (#73)"

### DIFF
--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -47,7 +47,7 @@ def buildEnvironments = [
 
   // NB: This image is taken from Caffe2
   //"py3.6-clang7-rocmdeb-ubuntu16.04",
-  "pytorch-linux-xenial-rocm3.5.1-py3.6",
+  "pytorch-linux-xenial-rocm3.3-py3.6",
 
   // This is really expensive to run because it is a total build
   // from scratch.  Maybe we have to do it nightly.
@@ -76,7 +76,7 @@ def splitTestEnvironments = [
   "pytorch-linux-xenial-py3-clang5-asan",
   "py3.6-clang7-rocmdeb-ubuntu16.04",
   "py3.6-clang8-rocmdeb-ubuntu16.04",
-  "pytorch-linux-xenial-rocm3.5.1-py3.6",
+  "pytorch-linux-xenial-rocm3.3-py3.6",
 ]
 def avxConfigTestEnvironment = "pytorch-linux-xenial-cuda8-cudnn6-py3"
 

--- a/src/main/groovy/ossci/caffe2/DockerVersion.groovy
+++ b/src/main/groovy/ossci/caffe2/DockerVersion.groovy
@@ -1,6 +1,6 @@
 // This file is manually managed
 package ossci.caffe2
 class DockerVersion {
-  static final String version = "ab1632df-fa59-40e6-8c23-98e004f61148";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
+  static final String version = "be76e8fd-44e2-484d-b090-07e0cc3a56f0";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
   static final String allDeployedVersions = "376,373,348,345,336,325,324,315,306,301,287,283,276,273,266,253,248,238,230,213";  // NOTE: this is a comma-separated list. E.g. "262,220,219"
 }

--- a/src/main/groovy/ossci/caffe2/Images.groovy
+++ b/src/main/groovy/ossci/caffe2/Images.groovy
@@ -87,7 +87,7 @@ class Images {
     //'py3.6-clang8-rocmdeb-ubuntu16.04',
     //'py2-devtoolset7-rocmrpm-centos7.5',
     //'py3.6-devtoolset7-rocmrpm-centos7',
-    'pytorch-linux-xenial-rocm3.5.1-py3.6',
+    'pytorch-linux-xenial-rocm3.3-py3.6',
   ];
 
   /////////////////////////////////////////////////////////////////////////////
@@ -260,7 +260,7 @@ class Images {
     // 'py2-gcc4.8-ubuntu14.04',
 
     //'py3.6-devtoolset7-rocmrpm-centos7',
-    'pytorch-linux-xenial-rocm3.5.1-py3.6',
+    'pytorch-linux-xenial-rocm3.3-py3.6',
   ];
 
   static final List<String> buildOnlyEnvironments = [

--- a/src/main/groovy/ossci/pytorch/DockerVersion.groovy
+++ b/src/main/groovy/ossci/pytorch/DockerVersion.groovy
@@ -7,7 +7,7 @@ package ossci.pytorch
 class DockerVersion {
   // WARNING: if you change this to a new version number,
   // you **MUST** also add that version number to the allDeployedVersions list below
-  static final String version = "ab1632df-fa59-40e6-8c23-98e004f61148";
+  static final String version = "be76e8fd-44e2-484d-b090-07e0cc3a56f0";
 
   // NOTE: this is a comma-separated list. E.g. "262,220,219"
   static final String allDeployedVersions = "271,262,256,278,282,291,300,323,327,347,389,401,402,403,405";


### PR DESCRIPTION
This reverts commit 7f0e30a0b17d5f1c3152c5386aaa0f242b69e425.