### PR TITLE
generate DOCKER_IMAGE_TAG based on git rev-parse

### DIFF
--- a/src/jobs/caffe2.groovy
+++ b/src/jobs/caffe2.groovy
@@ -99,7 +99,7 @@ Images.allDockerBuildEnvironments.each {
         ParametersUtil.GIT_COMMIT(delegate)
         ParametersUtil.GIT_MERGE_TARGET(delegate)
 
-        ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
+        ParametersUtil.DOCKER_IMAGE_TAG(delegate)
         ParametersUtil.CMAKE_ARGS(delegate)
 
         ParametersUtil.GITHUB_REPO(delegate, 'pytorch/pytorch')
@@ -134,6 +134,8 @@ Images.allDockerBuildEnvironments.each {
         // you don't need a pull request trigger job to test any branch
         // after merging it into any other branch (not just origin/master).
         // GitUtil.resolveAndSaveParameters(delegate, gitPropertiesFile)
+
+        GitUtil.generateImageTag(delegate)
 
         // Different triggers (build and run tests or build only)
         // means we have to use different tags, or we risk conflicting
@@ -346,7 +348,7 @@ git status
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
 
-      ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
+      ParametersUtil.DOCKER_IMAGE_TAG(delegate)
 
       ParametersUtil.GITHUB_REPO(delegate, 'pytorch/pytorch')
 
@@ -369,6 +371,7 @@ git status
 
     steps {
       GitUtil.mergeStep(delegate)
+      GitUtil.generateImageTag(delegate)
 
       environmentVariables {
         env(
@@ -457,7 +460,7 @@ fi
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
 
-      ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
+      ParametersUtil.DOCKER_IMAGE_TAG(delegate)
       ParametersUtil.HYPOTHESIS_SEED(delegate)
 
       ParametersUtil.GITHUB_REPO(delegate, 'pytorch/pytorch')
@@ -472,6 +475,7 @@ fi
 
     steps {
       GitUtil.mergeStep(delegate)
+      GitUtil.generateImageTag(delegate)
 
       environmentVariables {
         env(
@@ -583,7 +587,7 @@ rm -f ./crash/core.logging_test.*
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
 
-      ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
+      ParametersUtil.DOCKER_IMAGE_TAG(delegate)
       ParametersUtil.HYPOTHESIS_SEED(delegate)
 
       ParametersUtil.GITHUB_REPO(delegate, 'pytorch/pytorch')
@@ -598,6 +602,7 @@ rm -f ./crash/core.logging_test.*
 
     steps {
       GitUtil.mergeStep(delegate)
+      GitUtil.generateImageTag(delegate)
 
       environmentVariables {
         env(

--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -99,8 +99,8 @@ def masterJobSettings = { context, repo, triggerOnPush, defaultCmakeArgs, commit
     parameters {
       ParametersUtil.IN_CI(delegate)
       ParametersUtil.RUN_DOCKER_ONLY(delegate)
-      ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
-      ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate, Caffe2DockerVersion.version)
+      ParametersUtil.DOCKER_IMAGE_TAG(delegate)
+      ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate)
       ParametersUtil.CMAKE_ARGS(delegate, defaultCmakeArgs)
       ParametersUtil.HYPOTHESIS_SEED(delegate)
     }
@@ -113,6 +113,7 @@ def masterJobSettings = { context, repo, triggerOnPush, defaultCmakeArgs, commit
     steps {
       def gitPropertiesFile = './git.properties'
       GitUtil.resolveAndSaveParameters(delegate, gitPropertiesFile)
+      GitUtil.generateImageTag(delegate)
 
       phase("Master jobs") {
         buildEnvironments.each {
@@ -188,8 +189,8 @@ def pullRequestJobSettings = { context, repo, commitSource ->
     JobUtil.gitHubPullRequestTrigger(delegate, repo, pytorchbotAuthId, Users)
     parameters {
       ParametersUtil.IN_CI(delegate)
-      ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
-      ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate, Caffe2DockerVersion.version)
+      ParametersUtil.DOCKER_IMAGE_TAG(delegate)
+      ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate)
       ParametersUtil.CMAKE_ARGS(delegate)
       ParametersUtil.HYPOTHESIS_SEED(delegate)
     }
@@ -204,6 +205,7 @@ def pullRequestJobSettings = { context, repo, commitSource ->
 
       GitUtil.mergeStep(delegate)
       GitUtil.resolveAndSaveParameters(delegate, gitPropertiesFile)
+      GitUtil.generateImageTag(delegate)
 
       environmentVariables {
         propertiesFile(gitPropertiesFile)
@@ -311,8 +313,8 @@ def lintCheckBuildEnvironment = 'pytorch-linux-trusty-py2.7'
       ParametersUtil.IN_CI(delegate)
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
-      ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
-      ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate, Caffe2DockerVersion.version)
+      ParametersUtil.DOCKER_IMAGE_TAG(delegate)
+      ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate)
       ParametersUtil.COMMIT_SOURCE(delegate)
       ParametersUtil.GITHUB_REPO(delegate, 'pytorch/pytorch')
 
@@ -337,6 +339,8 @@ def lintCheckBuildEnvironment = 'pytorch-linux-trusty-py2.7'
     } // wrappers
 
     steps {
+      GitUtil.generateImageTag(delegate)
+
       def builtImageTag = 'tmp-${DOCKER_IMAGE_TAG}-${GIT_COMMIT}'
       def caffe2BuiltImageTag = 'tmp-${CAFFE2_DOCKER_IMAGE_TAG}-${GIT_COMMIT}'
       def builtImageId = '${GIT_COMMIT}'
@@ -462,8 +466,8 @@ def lintCheckBuildEnvironment = 'pytorch-linux-trusty-py2.7'
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
 
-      ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
-      ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate, Caffe2DockerVersion.version)
+      ParametersUtil.DOCKER_IMAGE_TAG(delegate)
+      ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate)
 
       ParametersUtil.GITHUB_REPO(delegate, 'pytorch/pytorch')
 
@@ -489,6 +493,7 @@ def lintCheckBuildEnvironment = 'pytorch-linux-trusty-py2.7'
 
     steps {
       GitUtil.mergeStep(delegate)
+      GitUtil.generateImageTag(delegate)
 
       environmentVariables {
         // TODO: Will be obsolete once this is baked into docker image
@@ -749,8 +754,8 @@ fi
 
         parameters {
           ParametersUtil.IN_CI(delegate)
-          ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
-          ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate, Caffe2DockerVersion.version)
+          ParametersUtil.DOCKER_IMAGE_TAG(delegate)
+          ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate)
 
           booleanParam(
             'RUN_TESTS',
@@ -785,6 +790,8 @@ fi
         }
 
         steps {
+          GitUtil.generateImageTag(delegate)
+
           // TODO: Will be obsolete once this is baked into docker image
           environmentVariables {
             env(

--- a/src/main/groovy/ossci/GitUtil.groovy
+++ b/src/main/groovy/ossci/GitUtil.groovy
@@ -51,6 +51,17 @@ class GitUtil {
 
   // OTHER STUFF
 
+  static void generateImageTag(StepContext context) {
+    context.with {
+      shell '''
+set -ex
+export GENERATED_DOCKER_IMAGE_TAG=$(git rev-parse HEAD:.circleci/docker)
+export DOCKER_IMAGE_TAG=${DOCKER_IMAGE_TAG:-$GENERATED_DOCKER_IMAGE_TAG}
+export CAFFE2_DOCKER_IMAGE_TAG=${CAFFE2_DOCKER_IMAGE_TAG:-$GENERATED_DOCKER_IMAGE_TAG}
+'''
+    }
+  }
+
   static void mergeStep(StepContext context) {
     context.with {
       // Merge GIT_COMMIT into GIT_MERGE_TARGET, if set
@@ -83,6 +94,10 @@ if [ -z "\${GIT_COMMIT}" ]; then
 else
   echo "GIT_COMMIT=\$(git rev-parse \${GIT_COMMIT})" >> "${file}"
 fi
+
+echo "GENERATED_DOCKER_IMAGE_TAG=\$(git rev-parse HEAD:.circleci/docker)" >> "${file}"
+echo "DOCKER_IMAGE_TAG=\${DOCKER_IMAGE_TAG:-\$GENERATED_DOCKER_IMAGE_TAG}" >> "${file}"
+echo "CAFFE2_DOCKER_IMAGE_TAG=\${CAFFE2_DOCKER_IMAGE_TAG:-\$GENERATED_DOCKER_IMAGE_TAG}" >> "${file}"
 
 if [ -n "\${GIT_MERGE_TARGET}" ]; then
   echo "GIT_MERGE_TARGET=\$(git rev-parse \${GIT_MERGE_TARGET})" >> "${file}"


### PR DESCRIPTION
This ports similar logic from the circleci agents.

Remove all pytorch and caffe2 uses of DockerVersion.version -- defaults now to empty string.