### PR TITLE
add IN_CI env var to pytorch and caffe2 jobs

### DIFF
--- a/src/jobs/caffe2.groovy
+++ b/src/jobs/caffe2.groovy
@@ -95,6 +95,7 @@ Images.allDockerBuildEnvironments.each {
       JobUtil.subJobDownstreamCommitStatus(delegate, gitHubName)
 
       parameters {
+        ParametersUtil.IN_CI(delegate)
         ParametersUtil.GIT_COMMIT(delegate)
         ParametersUtil.GIT_MERGE_TARGET(delegate)
 
@@ -341,6 +342,7 @@ git status
     JobUtil.gitCommitFromPublicGitHub(delegate, '${GITHUB_REPO}')
 
     parameters {
+      ParametersUtil.IN_CI(delegate)
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
 
@@ -451,6 +453,7 @@ fi
     JobUtil.gitCommitFromPublicGitHub(delegate, '${GITHUB_REPO}')
 
     parameters {
+      ParametersUtil.IN_CI(delegate)
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
 
@@ -576,6 +579,7 @@ rm -f ./crash/core.logging_test.*
     JobUtil.gitCommitFromPublicGitHub(delegate, '${GITHUB_REPO}')
 
     parameters {
+      ParametersUtil.IN_CI(delegate)
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
 

--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -97,6 +97,7 @@ def masterJobSettings = { context, repo, triggerOnPush, defaultCmakeArgs, commit
   context.with {
     JobUtil.masterTrigger(delegate, repo, "master", triggerOnPush)
     parameters {
+      ParametersUtil.IN_CI(delegate)
       ParametersUtil.RUN_DOCKER_ONLY(delegate)
       ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
       ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate, Caffe2DockerVersion.version)
@@ -186,6 +187,7 @@ def pullRequestJobSettings = { context, repo, commitSource ->
   context.with {
     JobUtil.gitHubPullRequestTrigger(delegate, repo, pytorchbotAuthId, Users)
     parameters {
+      ParametersUtil.IN_CI(delegate)
       ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
       ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate, Caffe2DockerVersion.version)
       ParametersUtil.CMAKE_ARGS(delegate)
@@ -306,6 +308,7 @@ def lintCheckBuildEnvironment = 'pytorch-linux-trusty-py2.7'
     JobUtil.subJobDownstreamCommitStatus(delegate, buildEnvironment)
 
     parameters {
+      ParametersUtil.IN_CI(delegate)
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
       ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
@@ -455,6 +458,7 @@ def lintCheckBuildEnvironment = 'pytorch-linux-trusty-py2.7'
     JobUtil.gitCommitFromPublicGitHub(delegate, '${GITHUB_REPO}')
 
     parameters {
+      ParametersUtil.IN_CI(delegate)
       ParametersUtil.GIT_COMMIT(delegate)
       ParametersUtil.GIT_MERGE_TARGET(delegate)
 
@@ -744,6 +748,7 @@ fi
         JobUtil.timeoutAndFailAfter(delegate, 180)
 
         parameters {
+          ParametersUtil.IN_CI(delegate)
           ParametersUtil.DOCKER_IMAGE_TAG(delegate, DockerVersion.version)
           ParametersUtil.CAFFE2_DOCKER_IMAGE_TAG(delegate, Caffe2DockerVersion.version)
 

--- a/src/main/groovy/ossci/ParametersUtil.groovy
+++ b/src/main/groovy/ossci/ParametersUtil.groovy
@@ -6,6 +6,16 @@ import javaposse.jobdsl.dsl.helpers.BuildParametersContext
  * Helper functions to use in 'parameters' contexts (in 'job'/'multiJob'/etc)
  */
 class ParametersUtil {
+  static void IN_CI(BuildParametersContext context, defaultValue = true) {
+    context.with {
+      booleanParam(
+          'IN_CI',
+          defaultValue,
+          'Indicate this is a CI job to enable special behavior for CI runs'
+      )
+    }
+  }
+
   static void RUN_DOCKER_ONLY(BuildParametersContext context, defaultValue = false) {
     context.with {
       booleanParam(


### PR DESCRIPTION
This brings Jenkins in line with CircleCI as a universal indicator that these are CI jobs.