### PR TITLE
disable caffe2-master-debug daily cron job

### DIFF
--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -175,13 +175,12 @@ multiJob("pytorch-master") {
 //  masterJobSettings(delegate, "ROCmSoftwarePlatform/pytorch", "rocm-master", rocmMailRecipients)
 //}
 
+// we tried commenting this out before, but the cron trigger still fired
+// let's try keeping the job, but removing the cron trigger
 // Runs on debug build on master (triggered nightly)
-//multiJob("caffe2-master-debug") {
-//  masterJobSettings(delegate, "pytorch/pytorch", false, '-DCMAKE_BUILD_TYPE=DEBUG', "master", mailRecipients)
-//  triggers {
-//    cron('@daily')
-//  }
-//}
+multiJob("caffe2-master-debug") {
+  masterJobSettings(delegate, "pytorch/pytorch", false, '-DCMAKE_BUILD_TYPE=DEBUG', "master", mailRecipients)
+}
 
 def pullRequestJobSettings = { context, repo, commitSource ->
   context.with {


### PR DESCRIPTION
We tried disabling this job before, but the daily cron job remained.  Let's try keeping the job definition but removing the cron trigger.