### PR TITLE
disable jobs if targeting lts branch

### DIFF
--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -207,6 +207,15 @@ def pullRequestJobSettings = { context, repo, commitSource ->
         propertiesFile(gitPropertiesFile)
       }
 
+      phase("Skip if targeting LTS branch") {
+        // No jenkins jobs should run on LTS branches
+        def pr_build_target_branch_blacklist = ~/^lts*/
+        if (pr_build_target_branch_blacklist.matcher("${env.ghprbTargetBranch}").matches()) {
+          currentBuild.result = 'SUCCESS'
+          return
+        }
+      }
+
       phase("Build and test") {
         // PyTorch
         buildEnvironments.each {


### PR DESCRIPTION
LTS branches do not generally want jenkins jobs running for them

I don't really know how to test this without just deploying it, seeking guidance @ezyang, @jeffdaily, @jithunnair-amd 

Signed-off-by: Eli Uriegas <eliuriegas@fb.com>