### PR TITLE
Fix for skipping of LTS branches, second attempt.

### DIFF
--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -218,15 +218,6 @@ def pullRequestJobSettings = { context, repo, commitSource ->
         propertiesFile(gitPropertiesFile)
       }
 
-      phase("Skip if targeting LTS branch") {
-        // No jenkins jobs should run on LTS branches
-        def pr_build_target_branch_blacklist = ~/^lts*/
-        if (pr_build_target_branch_blacklist.matcher("${ghprbTargetBranch}").matches()) {
-          currentBuild.result = 'SUCCESS'
-          return
-        }
-      }
-
       phase("Build and test") {
         // PyTorch
         buildEnvironments.each {

--- a/src/main/groovy/ossci/JobUtil.groovy
+++ b/src/main/groovy/ossci/JobUtil.groovy
@@ -197,6 +197,9 @@ class JobUtil {
           // currently only being used by caffe2
           blackListLabels(['skip-tests'])
 
+          // No jenkins job should run on LTS branches
+          blackListTargetBranches(['^lts*'])
+
           // Only build the PR if it targets 'master'
           // 'sending_pr' is a special case for ROCmSoftwarePlatform/pytorch
           // 'tensor-merge' is a temporary working branch for tensor


### PR DESCRIPTION
Use blackListTargetBranches feature of ghprb.

CC @jithunnair-amd @seemethere 