### PR TITLE
update docker image tag to pick up new magma version

### DIFF
--- a/src/main/groovy/ossci/caffe2/DockerVersion.groovy
+++ b/src/main/groovy/ossci/caffe2/DockerVersion.groovy
@@ -1,6 +1,6 @@
 // This file is manually managed
 package ossci.caffe2
 class DockerVersion {
-  static final String version = "74e757e8b0cf750d2f91db6aa4c29640abce32ea";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
+  static final String version = "58400dcd94fa85d438c0336b8f0de5180cfa8da3";  // WARNING: if you change this to a new version number, you **MUST** also add that version number to the allDeployedVersions list below
   static final String allDeployedVersions = "376,373,348,345,336,325,324,315,306,301,287,283,276,273,266,253,248,238,230,213";  // NOTE: this is a comma-separated list. E.g. "262,220,219"
 }

--- a/src/main/groovy/ossci/pytorch/DockerVersion.groovy
+++ b/src/main/groovy/ossci/pytorch/DockerVersion.groovy
@@ -7,7 +7,7 @@ package ossci.pytorch
 class DockerVersion {
   // WARNING: if you change this to a new version number,
   // you **MUST** also add that version number to the allDeployedVersions list below
-  static final String version = "74e757e8b0cf750d2f91db6aa4c29640abce32ea";
+  static final String version = "58400dcd94fa85d438c0336b8f0de5180cfa8da3";
 
   // NOTE: this is a comma-separated list. E.g. "262,220,219"
   static final String allDeployedVersions = "271,262,256,278,282,291,300,323,327,347,389,401,402,403,405";


### PR DESCRIPTION
New tag comes from https://github.com/pytorch/pytorch/pull/67225.