### PR TITLE
wsCleanup() post build for master and pull request triggers

### DIFF
--- a/src/jobs/pytorch.groovy
+++ b/src/jobs/pytorch.groovy
@@ -167,6 +167,7 @@ def masterJobSettings = { context, repo, triggerOnPush, enablePytorch, enableCaf
     }
     publishers {
       mailer(localMailRecipients, false, true)
+      wsCleanup()
     }
   }
 }
@@ -264,6 +265,9 @@ def pullRequestJobSettings = { context, repo, commitSource ->
         //  }
         //}
       }
+    }
+    publishers {
+      wsCleanup()
     }
   }
 }


### PR DESCRIPTION
Otherwise, too many concurrent builds will run out of disk on trigger3.
Even though wsCleanup() takes place at start of build, disk will fill.