### PR TITLE
Add --allow-unrelated-histories flag to workaround git merge error in nightly CI runs

### DIFF
--- a/src/main/groovy/ossci/GitUtil.groovy
+++ b/src/main/groovy/ossci/GitUtil.groovy
@@ -59,7 +59,7 @@ class GitUtil {
 set -ex
 if [ -n "${GIT_MERGE_TARGET}" ]; then
   git reset --hard ${GIT_COMMIT}
-  git merge --no-ff ${GIT_MERGE_TARGET}
+  git merge --no-ff --allow-unrelated-histories ${GIT_MERGE_TARGET}
 fi
 '''
     }


### PR DESCRIPTION
'fatal: refusing to merge unrelated histories'
Eg: https://ci.pytorch.org/jenkins/job/pytorch-builds/job/pytorch-linux-bionic-rocm4.3.1-py3.6-build/14390/console