### PR TITLE
forcibly remove .git directory after properties are saved

### DIFF
--- a/src/main/groovy/ossci/GitUtil.groovy
+++ b/src/main/groovy/ossci/GitUtil.groovy
@@ -114,6 +114,9 @@ else
   # FIX ME
   echo "CAFFE2_CHANGED=0" >> "${file}"
 fi
+
+# after parameters saved, try to prevent running out of disk space on trigger host
+rm -rf .git
 """
     }
   }


### PR DESCRIPTION
Hopefully this fixes the out of disk issues on trigger.